### PR TITLE
Add onnx_op higher version shortcut for onnx 1.14.0 test suites

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -5,57 +5,22 @@
 The following is a set of guidelines, but not rules, for contributing to jaxonnxruntime.
 Use your best judgment, and feel free to propose changes to this document in a pull request.
 
+We follow most best best practices of google/flax project [https://github.com/google/flax/blob/main/docs/contributing.md].
+
+Here we only list those difference.
+
 ---
 
 #### Table of Contents
 
-[Getting Started](#getting-started)
-
-[What Kind of Contributions Are Welcome?](#what-kind-of-contributions-are-welcome)
-
-[How to Contribute?](#how-to-contribute)
-* [Reporting Bugs](#reporting-bugs)
-* [Adding Support for New Operators](#adding-support-for-new-operators)
-* [Code Review](#code-review)
-
-[Code of Conduct](#code-of-conduct)
+- [Contributing to jaxonnxruntime](#contributing-to-jaxonnxruntime)
+      - [Table of Contents](#table-of-contents)
+  - [How to Contribute?](#how-to-contribute)
+    - [Adding Support for New Operators](#adding-support-for-new-operators)
 
 ---
 
-## Getting Started
-
-To get started contributing, please:
-
-1. Fork the repository to your own GitHub account.
-2. Clone the repository to your local machine.
-3. Create a branch locally with a succinct but descriptive name.
-4. Commit changes to the branch.
-5. Follow any formatting and testing guidelines specific to this repo.
-6. Push changes to your fork.
-7. Open a pull request in our repository and follow the pull request template so that we can efficiently review the changes.
-
-## What Kind of Contributions Are Welcome?
-
-We welcome all kinds of contributions, including:
-
-* Bug fixes
-* New features
-* Documentation improvements
-* Translations
-
 ## How to Contribute?
-
-### Reporting Bugs
-
-<!--- Maybe add a bug report template? --->
-Bugs are tracked as [Github Issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues).
-Please explain the problem and include additional details to help maintainers reproduce the problem:
-
-* Use a clear and descriptive title.
-* Describe the exact steps which reproduce the problem in as many details as possible.
-* Provide specific examples to demonstrate the steps.
-* Describe the behavior you observed after following the steps and point out what exactly is the problem with that behavior.
-* Explain which behavior you expected to see instead and why.
 
 ### Adding Support for New Operators
 
@@ -81,16 +46,3 @@ Make sure all tests are passed before submitting a pull request.
 ```shell
 $ python tests/onnx_ops_test.py
 ```
-
-### Code Review
-
-All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose.
-Consult [GitHub Help](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more information on using pull requests.
-<!--- Maybe add a pull request template? --->
-
-## Code of Conduct
-
-This project follows [Google's Open Source Community Guidelines](https://opensource.google/conduct/).
-Please follow the guidelines in all your interactions with the project community.
-
-Thank you for contributing!

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,5 +17,3 @@ absl-py
 # The next packages are for notebooks.
 matplotlib
 scikit-learn
-# Must install itself for notebook execution and autodocs to work.
-.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,6 +12,8 @@ jupytext==1.13.8
 # ReadTheDocs: https://stackoverflow.com/a/68008428
 docutils==0.16
 
+absl-py
+
 # The next packages are for notebooks.
 matplotlib
 scikit-learn

--- a/jaxonnxruntime/onnx_ops/averagepool.py
+++ b/jaxonnxruntime/onnx_ops/averagepool.py
@@ -64,6 +64,14 @@ class AveragePool(handler.Handler):
     cls._prepare(node, inputs, onnx_averagepool)
     return onnx_averagepool
 
+  @classmethod
+  def version_19(
+      cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
+  ) -> Callable[..., Any]:
+    """ONNX version_19 AveragePool op."""
+    cls._prepare(node, inputs, onnx_averagepool)
+    return onnx_averagepool
+
 
 @functools.partial(
     jit,

--- a/jaxonnxruntime/onnx_ops/cast.py
+++ b/jaxonnxruntime/onnx_ops/cast.py
@@ -76,6 +76,14 @@ class Cast(handler.Handler):
     cls._prepare(node, inputs, onnx_cast)
     return onnx_cast
 
+  @classmethod
+  def version_19(
+      cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
+  ) -> Callable[..., Any]:
+    """ONNX version_19 Cast op."""
+    cls._prepare(node, inputs, onnx_cast)
+    return onnx_cast
+
 
 @functools.partial(jit, static_argnames=("to", "from_type"))
 def onnx_cast(x, *, to, from_type=None):

--- a/jaxonnxruntime/onnx_ops/constant.py
+++ b/jaxonnxruntime/onnx_ops/constant.py
@@ -89,6 +89,13 @@ class Constant(handler.Handler):
     cls._prepare(node, inputs, onnx_constant)
     return onnx_constant
 
+  @classmethod
+  def version_19(
+      cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
+  ) -> Callable[..., Any]:
+    """ONNX version_19 Constant op."""
+    cls._prepare(node, inputs, onnx_constant)
+    return onnx_constant
 
 @functools.partial(jit, static_argnames=())
 def onnx_constant(*input_args, value):

--- a/jaxonnxruntime/onnx_ops/equal.py
+++ b/jaxonnxruntime/onnx_ops/equal.py
@@ -64,6 +64,14 @@ class Equal(handler.Handler):
     cls._prepare(node, inputs, onnx_equal)
     return onnx_equal
 
+  @classmethod
+  def version_19(
+      cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
+  ) -> Callable[..., Any]:
+    """ONNX version_19 Equal op."""
+    cls._prepare(node, inputs, onnx_equal)
+    return onnx_equal
+
 
 @functools.partial(jit, static_argnames=())
 def onnx_equal(*input_args):

--- a/jaxonnxruntime/onnx_ops/identity.py
+++ b/jaxonnxruntime/onnx_ops/identity.py
@@ -63,6 +63,13 @@ class Identity(handler.Handler):
     cls._prepare(node, inputs, onnx_identity)
     return onnx_identity
 
+  @classmethod
+  def version_19(
+      cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
+  ) -> Callable[..., Any]:
+    """ONNX version_19 Identity op."""
+    cls._prepare(node, inputs, onnx_identity)
+    return onnx_identity
 
 @functools.partial(jit, static_argnames=())
 def onnx_identity(*input_args):

--- a/jaxonnxruntime/onnx_ops/pad.py
+++ b/jaxonnxruntime/onnx_ops/pad.py
@@ -69,6 +69,13 @@ class Pad(handler.Handler):
     cls._prepare(node, inputs, onnx_pad)
     return onnx_pad
 
+  @classmethod
+  def version_19(
+      cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
+  ) -> Callable[..., Any]:
+    """ONNX version_19 Pad op."""
+    cls._prepare(node, inputs, onnx_pad)
+    return onnx_pad
 
 @functools.partial(jit, static_argnames=('pads', 'constant_value', 'mode'))
 def onnx_pad(*input_args, pads, constant_value=0.0, mode='constant'):

--- a/jaxonnxruntime/onnx_ops/reducemax.py
+++ b/jaxonnxruntime/onnx_ops/reducemax.py
@@ -66,6 +66,15 @@ class ReduceMax(handler.Handler):
     return onnx_reducemax
 
 
+  @classmethod
+  def version_18(
+      cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
+  ) -> Callable[..., Any]:
+    """ONNX version_18 ReduceMax op."""
+    cls._prepare(node, inputs, onnx_reducemax)
+    return onnx_reducemax
+
+
 @functools.partial(jit, static_argnames=('axes', 'keepdims'))
 def onnx_reducemax(*input_args, axes, keepdims=True):
   """The impl for https://github.com/onnx/onnx/blob/v1.12.0/docs/Operators.md#ReduceMax."""

--- a/jaxonnxruntime/onnx_ops/reducemean.py
+++ b/jaxonnxruntime/onnx_ops/reducemean.py
@@ -63,6 +63,14 @@ class ReduceMean(handler.Handler):
     cls._prepare(node, inputs, onnx_reducemean)
     return onnx_reducemean
 
+  @classmethod
+  def version_18(
+      cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
+  ) -> Callable[..., Any]:
+    """ONNX version_18 ReduceMean op."""
+    cls._prepare(node, inputs, onnx_reducemean)
+    return onnx_reducemean
+
 
 @functools.partial(jit, static_argnames=('axes', 'keepdims'))
 def onnx_reducemean(*input_args, axes=None, keepdims=True):

--- a/jaxonnxruntime/onnx_ops/reshape.py
+++ b/jaxonnxruntime/onnx_ops/reshape.py
@@ -64,6 +64,14 @@ class Reshape(handler.Handler):
     cls._prepare(node, inputs, onnx_reshape)
     return onnx_reshape
 
+  @classmethod
+  def version_19(
+      cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
+  ) -> Callable[..., Any]:
+    """ONNX version_19 Reshape op."""
+    cls._prepare(node, inputs, onnx_reshape)
+    return onnx_reshape
+
 
 @functools.partial(jit, static_argnames=('shape', 'allowzero'))
 def onnx_reshape(*input_args, shape, allowzero):

--- a/jaxonnxruntime/onnx_ops/shape.py
+++ b/jaxonnxruntime/onnx_ops/shape.py
@@ -62,6 +62,14 @@ class Shape(handler.Handler):
     cls._prepare(node, inputs, onnx_shape)
     return onnx_shape
 
+  @classmethod
+  def version_19(
+      cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
+  ) -> Callable[..., Any]:
+    """ONNX version_19 Shape op."""
+    cls._prepare(node, inputs, onnx_shape)
+    return onnx_shape
+
 
 @functools.partial(jit, static_argnames=('start', 'end'))
 def onnx_shape(*input_args, start=None, end=None):

--- a/jaxonnxruntime/onnx_ops/split.py
+++ b/jaxonnxruntime/onnx_ops/split.py
@@ -59,6 +59,14 @@ class Split(handler.Handler):
     cls._prepare(node, inputs, onnx_split)
     return onnx_split
 
+  @classmethod
+  def version_18(
+      cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
+  ) -> Callable[..., Any]:
+    """ONNX version_18 Split op."""
+    cls._prepare(node, inputs, onnx_split)
+    return onnx_split
+
 
 @functools.partial(jit, static_argnames=('split', 'axis', 'num_output'))
 def onnx_split(*input_args, num_output, split=None, axis=0):

--- a/tests/onnx_ops_test.py
+++ b/tests/onnx_ops_test.py
@@ -18,12 +18,14 @@ import collections
 from typing import Any
 
 from absl.testing import absltest
+import jax
 from jaxonnxruntime import config
 from jaxonnxruntime import runner
 from jaxonnxruntime.backend import Backend as JaxBackend  # pylint: disable=g-importing-member
 
 
 config.update('jaxort_only_allow_initializers_as_static_args', False)
+jax.config.update('jax_numpy_rank_promotion', 'allow')
 
 
 class Runner(runner.Runner):


### PR DESCRIPTION
The original code is based onnx 1.12.0 node test suites. This PR only add those high version shortcut in onnx_op implementation.  
This PR is not trying to fix those bugs by new 1.14.0 test suite. They should be fixed by other separated PRs.

