### PR TITLE
Add `Flatten` version 9

### DIFF
--- a/jaxonnxruntime/onnx_ops/flatten.py
+++ b/jaxonnxruntime/onnx_ops/flatten.py
@@ -55,7 +55,7 @@ class Flatten(handler.Handler):
   def version_9(
       cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
   ) -> Callable[..., Any]:
-    """ONNX version_1 Flatten op."""
+    """ONNX version_9 Flatten op."""
     cls._prepare(node, inputs, onnx_flatten)
     return onnx_flatten
 

--- a/jaxonnxruntime/onnx_ops/flatten.py
+++ b/jaxonnxruntime/onnx_ops/flatten.py
@@ -52,6 +52,14 @@ class Flatten(handler.Handler):
     return onnx_flatten
 
   @classmethod
+  def version_9(
+      cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
+  ) -> Callable[..., Any]:
+    """ONNX version_1 Flatten op."""
+    cls._prepare(node, inputs, onnx_flatten)
+    return onnx_flatten
+
+  @classmethod
   def version_11(
       cls, node: onnx_node.OnnxNode, inputs: Sequence[Any]
   ) -> Callable[..., Any]:


### PR DESCRIPTION
Hi, jaxonnxruntime is awesome! I truly believe it is incredibly useful and a great asset to the community.

In this PR, I added a version 9 of `Flatten` because I got the following error when I run an ONNX model in jaxonnxruntime.

```
    raise NotImplementedError(
NotImplementedError: Flatten version 9 is not implemented. Only have those versions: ['version_1', 'version_11', 'version_13'].
```

It looks like [there are version 1, 9, 11 and 13 in ONNX](https://github.com/onnx/onnx/blob/v1.15.0/docs/Operators.md) but currently [jaxonnxruntime only has 1, 11 and 13](https://github.com/google/jaxonnxruntime/blob/df6b9817a1e87c6ba5651579d8fe3565bc3fbbca/jaxonnxruntime/onnx_ops/flatten.py#L47-L68).
Note that this model works well with (non-jax) onnxruntime and I found it works well with jaxonnxruntime with this modification.

I read the [contributing.md](https://github.com/google/jaxonnxruntime/blob/main/contributing.md). As this PR is not for a new op but for a new version of existing ops, I suppose I do not need to add a new test.