### PR TITLE
Fix topological sort for graphs with non-used optional inputs specified as empty strings

### DIFF
--- a/jaxonnxruntime/core/onnx_graph.py
+++ b/jaxonnxruntime/core/onnx_graph.py
@@ -205,7 +205,7 @@ class OnnxGraph:
     outputs = node_down_to_tensor_dict[node_name]
     results = []
     for output_ in outputs:
-      if output_ in tensor_down_to_node_dict:
+      if output_ and output_ in tensor_down_to_node_dict:
         results.extend(tensor_down_to_node_dict[output_])
     return results
 


### PR DESCRIPTION
The current implementation of `graph.topological_sort()` encounters issues when handling nodes with optional inputs specified as empty strings. This behavior contradicts the ONNX spec, which allows empty strings for optional inputs/outputs (see [Optional Inputs and Outputs](https://github.com/onnx/onnx/blob/main/docs/IR.md#static-optional)).


The problem arises because  `graph.get_child_nodes_name(node_name)` considers all unused optional outputs in the graph as required inputs for nodes with empty string inputs.
This occurs because both the unused outputs and the empty string inputs have the same name (empty string).
This mismatch leads to the topological sorting getting stuck, resulting in a runtime error ("Graph has a cycle...") due to missing required inputs to progress.

**Proposed fix**

Modify `graph.get_child_nodes_name(node_name)` to ignore empty strings when determining child nodes. This ensures correct topological sorting for graphs with optional inputs as specified by the ONNX spec.