### PR TITLE
docs: fix typos in docstrings and comments

### DIFF
--- a/jaxonnxruntime/core/handler.py
+++ b/jaxonnxruntime/core/handler.py
@@ -69,7 +69,7 @@ class Handler:
   def handle(
       cls, node: OnnxNode, inputs: Sequence[Any], **kwargs
   ) -> Callable[..., Any]:
-    """Return the version method jax function depending on OnnxNode verison.
+    """Return the version method jax function depending on OnnxNode version.
 
     For example, onnx abs op with version 4 will call jax class `abs.version_4`
     API.

--- a/jaxonnxruntime/experimental/call_torch/_call_torch.py
+++ b/jaxonnxruntime/experimental/call_torch/_call_torch.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Convert PyTorch function to Jax funtion."""
+"""Convert PyTorch function to Jax function."""
 
 import io
 import os

--- a/jaxonnxruntime/experimental/call_torch/call_torch_xla.py
+++ b/jaxonnxruntime/experimental/call_torch/call_torch_xla.py
@@ -58,7 +58,7 @@ call_torch_xla_p.multiple_results = True
 
 
 def call_torch_xla(*args, module: Union[str, Any], clean_mhlo_attributes=True):
-  """Lower torch module to XLA and wrap it as JAX funtion.
+  """Lower torch module to XLA and wrap it as JAX function.
 
   Given the the torch module and its input arguments, this function will lower
   the torch module into stablehlo first. Then it wrap the stablehlo module as

--- a/jaxonnxruntime/experimental/custom_ops/zeros_like.py
+++ b/jaxonnxruntime/experimental/custom_ops/zeros_like.py
@@ -27,7 +27,7 @@
 # limitations under the License.
 """Define Custom ONNX ZerosLike operator.
 
-Here we demo how to reuse Tensorflow ops impelmentation.
+Here we demo how to reuse Tensorflow ops implementation.
 """
 
 

--- a/jaxonnxruntime/onnx_ops/if_op.py
+++ b/jaxonnxruntime/onnx_ops/if_op.py
@@ -138,7 +138,7 @@ def bypass_output_shape_check():
   Without this config, we require the output shape of else and then branches
   to be the same, which aligns with jax.lax.cond.
 
-  **Please add relevent global config to `config_list`.**
+  **Please add relevant global config to `config_list`.**
 
   Returns:
     bypass: Bool, whether to bypass the output shape check.

--- a/jaxonnxruntime/onnx_ops/scatternd.py
+++ b/jaxonnxruntime/onnx_ops/scatternd.py
@@ -117,7 +117,7 @@ def onnx_scatternd(*input_args, reduction: str):
 
   assert (
       indices.shape[: q - 1] == updates.shape[: q - 1]
-  ), "first q-1 dims of indicies and updates must match"
+  ), "first q-1 dims of indices and updates must match"
   assert (
       data.shape[k:] == updates.shape[q - 1 :]
   ), "last dimensions of data and updates must match"


### PR DESCRIPTION
Six spelling fixes across six files — docstrings and comments only:

- `scatternd.py`: `indicies` → `indices`
- `call_torch_xla.py`: `funtion` → `function`
- `_call_torch.py`: `funtion` → `function`
- `zeros_like.py`: `impelmentation` → `implementation`
- `handler.py`: `verison` → `version`
- `if_op.py`: `relevent` → `relevant`